### PR TITLE
Add support for inputstack arrays for FluidToFluid and FluidToItem

### DIFF
--- a/src/main/java/xt9/inworldcrafting/common/crafting/CraftingItem.java
+++ b/src/main/java/xt9/inworldcrafting/common/crafting/CraftingItem.java
@@ -79,6 +79,7 @@ public class CraftingItem {
             IBlockState state = world.getBlockState(item.getPosition());
             nearbyItems.clear();
             nearbyItems.addAll(WorldHelper.getAllItemEntitiesAtPosition(world, item.getPosition()));
+            nearbyItems.removeIf(entityItem -> world.getBlockState(entityItem.getPosition()) != state);
 
             if (!fluidToFluidRecipeIndexes.isEmpty()) {
                 fluidToFluidRecipeIndexes.forEach(i -> {

--- a/src/main/java/xt9/inworldcrafting/common/crafttweaker/FluidToFluid.java
+++ b/src/main/java/xt9/inworldcrafting/common/crafttweaker/FluidToFluid.java
@@ -61,7 +61,7 @@ public class FluidToFluid {
         }
 
         if (isValidOutBlock) {
-            EntityMatcher.allValidInputs.addAll(Arrays.asList(ingredients));
+            EntityMatcher.allValidInputs.add(ingredients[0]);
             FluidToFluidRecipe.addRecipe(outputFluidName, inputFluidName, ingredients, consume);
         }
     }

--- a/src/main/java/xt9/inworldcrafting/common/crafttweaker/FluidToFluid.java
+++ b/src/main/java/xt9/inworldcrafting/common/crafttweaker/FluidToFluid.java
@@ -12,6 +12,8 @@ import xt9.inworldcrafting.InWorldCrafting;
 import xt9.inworldcrafting.common.event.EntityMatcher;
 import xt9.inworldcrafting.common.recipe.FluidToFluidRecipe;
 
+import java.util.Arrays;
+
 /**
  * Created by xt9 on 2019-01-12.
  */
@@ -31,25 +33,38 @@ public class FluidToFluid {
 
     @ZenMethod
     public static void transform(ILiquidStack outputFluid, ILiquidStack inputFluid, IIngredient ingredient, boolean consume) {
+        transform(outputFluid, inputFluid, new IIngredient[]{ingredient}, consume);
+    }
+
+    @ZenMethod
+    public static void transform(ILiquidStack outputFluid, ILiquidStack inputFluid, IIngredient[] ingredients) {
+        transform(outputFluid, inputFluid, ingredients, true);
+    }
+
+    @ZenMethod
+    public static void transform(ILiquidStack outputFluid, ILiquidStack inputFluid, IIngredient[] ingredients, boolean consume) {
         /* Inputs should only be items or oredicts */
-        if(ingredient.getLiquids().size() > 0) { return; }
+        for (int i = 0; i < ingredients.length; i++) {
+            if (ingredients[i].getLiquids().size() > 0) {
+                return;
+            }
+        }
 
         String outputFluidName = getFluidName(outputFluid);
         String inputFluidName = getFluidName(inputFluid);
 
         boolean isValidOutBlock = true;
         Fluid outFluid = FluidRegistry.getFluid(outputFluidName);
-        if(outFluid.getBlock() == null) {
+        if (outFluid.getBlock() == null) {
             isValidOutBlock = false;
             CraftTweakerAPI.logError(InWorldCrafting.MODID + ": <liquid:" + outFluid.getName() + "> has no registered Block, it cannot be used as an Output for FluidToFluid crafting.");
         }
 
-        if(isValidOutBlock) {
-            EntityMatcher.allValidInputs.add(ingredient);
-            FluidToFluidRecipe.addRecipe(outputFluidName, inputFluidName, ingredient, ingredient.getAmount(), consume);
+        if (isValidOutBlock) {
+            EntityMatcher.allValidInputs.addAll(Arrays.asList(ingredients));
+            FluidToFluidRecipe.addRecipe(outputFluidName, inputFluidName, ingredients, consume);
         }
     }
-
 
     private static String getFluidName(ILiquidStack stack) {
         return stack.getDefinition().getName();

--- a/src/main/java/xt9/inworldcrafting/common/crafttweaker/FluidToItem.java
+++ b/src/main/java/xt9/inworldcrafting/common/crafttweaker/FluidToItem.java
@@ -10,6 +10,8 @@ import stanhebben.zenscript.annotations.ZenMethod;
 import xt9.inworldcrafting.common.event.EntityMatcher;
 import xt9.inworldcrafting.common.recipe.FluidToItemRecipe;
 
+import java.util.Arrays;
+
 /**
  * Created by xt9 on 2019-01-12.
  */
@@ -28,15 +30,28 @@ public class FluidToItem {
 
     @ZenMethod
     public static void transform(IItemStack outputItem, ILiquidStack inputFluid, IIngredient ingredient, boolean consume) {
+        transform(outputItem, inputFluid, new IIngredient[]{ingredient}, consume);
+    }
+
+    @ZenMethod
+    public static void transform(IItemStack outputItem, ILiquidStack inputFluid, IIngredient[] ingredients) {
+        transform(outputItem, inputFluid, ingredients, false);
+    }
+
+    @ZenMethod
+    public static void transform(IItemStack outputItem, ILiquidStack inputFluid, IIngredient[] ingredients, boolean consume) {
         /* Inputs should only be items or oredicts */
-        if(ingredient.getLiquids().size() > 0) { return; }
+        for (int i = 0; i < ingredients.length; i++) {
+            if (ingredients[i].getLiquids().size() > 0) {
+                return;
+            }
+        }
 
         ItemStack outputItemStack = CraftTweakerMC.getItemStack(outputItem);
         String inputFluidName = getFluidName(inputFluid);
 
-
-        EntityMatcher.allValidInputs.add(ingredient);
-        FluidToItemRecipe.addRecipe(outputItemStack, inputFluidName, ingredient, ingredient.getAmount(), consume);
+        EntityMatcher.allValidInputs.addAll(Arrays.asList(ingredients));
+        FluidToItemRecipe.addRecipe(outputItemStack, inputFluidName, ingredients, consume);
     }
 
     private static String getFluidName(ILiquidStack stack) {

--- a/src/main/java/xt9/inworldcrafting/common/crafttweaker/FluidToItem.java
+++ b/src/main/java/xt9/inworldcrafting/common/crafttweaker/FluidToItem.java
@@ -50,7 +50,7 @@ public class FluidToItem {
         ItemStack outputItemStack = CraftTweakerMC.getItemStack(outputItem);
         String inputFluidName = getFluidName(inputFluid);
 
-        EntityMatcher.allValidInputs.addAll(Arrays.asList(ingredients));
+        EntityMatcher.allValidInputs.add(ingredients[0]);
         FluidToItemRecipe.addRecipe(outputItemStack, inputFluidName, ingredients, consume);
     }
 

--- a/src/main/java/xt9/inworldcrafting/common/event/EntityMatcher.java
+++ b/src/main/java/xt9/inworldcrafting/common/event/EntityMatcher.java
@@ -34,7 +34,7 @@ public class EntityMatcher {
 
             boolean match = false;
             for (IIngredient input : allValidInputs) {
-                if(input.matches(CraftTweakerMC.getIItemStack(spawnedStack))) {
+                if(input.amount(1).matches(CraftTweakerMC.getIItemStack(spawnedStack))) {
                     match = true;
                 }
             }
@@ -58,16 +58,24 @@ public class EntityMatcher {
 
     private static void matchFluidToFluidRecipes(ItemStack spawnedStack, CraftingItem craftingItem) {
         for (int i = 0; i < FluidToFluidRecipe.recipes.size(); i++) {
-            if(FluidToFluidRecipe.recipes.get(i).getInputs().matches(CraftTweakerMC.getIItemStack(spawnedStack))) {
-                craftingItem.addFluidToFluidRecipeIndex(i);
+            IIngredient[] ingredients = FluidToFluidRecipe.recipes.get(i).getInputs();
+            for (int j = 0; j < ingredients.length; j++) {
+                if(ingredients[j].amount(1).matches(CraftTweakerMC.getIItemStack(spawnedStack))) {
+                    craftingItem.addFluidToFluidRecipeIndex(i);
+                    break;
+                }
             }
         }
     }
 
     private static void matchFluidToItemRecipes(ItemStack spawnedStack, CraftingItem craftingItem) {
         for (int i = 0; i < FluidToItemRecipe.recipes.size(); i++) {
-            if(FluidToItemRecipe.recipes.get(i).getInputs().matches(CraftTweakerMC.getIItemStack(spawnedStack))) {
-                craftingItem.addFluidToItemRecipeIndex(i);
+            IIngredient[] ingredients = FluidToItemRecipe.recipes.get(i).getInputs();
+            for (int j = 0; j < ingredients.length; j++) {
+                if(ingredients[j].amount(1).matches(CraftTweakerMC.getIItemStack(spawnedStack))) {
+                    craftingItem.addFluidToItemRecipeIndex(i);
+                    break;
+                }
             }
         }
     }

--- a/src/main/java/xt9/inworldcrafting/common/recipe/FluidToFluidRecipe.java
+++ b/src/main/java/xt9/inworldcrafting/common/recipe/FluidToFluidRecipe.java
@@ -1,8 +1,6 @@
 package xt9.inworldcrafting.common.recipe;
 
 import crafttweaker.api.item.IIngredient;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.NonNullList;
 
 import java.util.ArrayList;
 
@@ -14,20 +12,18 @@ public class FluidToFluidRecipe {
 
     private String outputFluid;
     private String inputFluid;
-    private IIngredient inputs;
-    private int inputAmount;
+    private IIngredient[] inputs;
     private boolean consume;
 
-    private FluidToFluidRecipe(String outputFluid, String inputFluid, IIngredient inputs, int inputAmount, boolean consume) {
+    private FluidToFluidRecipe(String outputFluid, String inputFluid, IIngredient[] inputs, boolean consume) {
         this.outputFluid = outputFluid;
         this.inputFluid = inputFluid;
         this.inputs = inputs;
-        this.inputAmount = inputAmount;
         this.consume = consume;
     }
 
-    public static void addRecipe(String outputFluid, String inputFluid, IIngredient inputs, int inputAmount, boolean consume) {
-        recipes.add(new FluidToFluidRecipe(outputFluid, inputFluid, inputs, inputAmount, consume));
+    public static void addRecipe(String outputFluid, String inputFluid, IIngredient[] inputs, boolean consume) {
+        recipes.add(new FluidToFluidRecipe(outputFluid, inputFluid, inputs, consume));
     }
 
     public String getOutputFluid() {
@@ -42,11 +38,7 @@ public class FluidToFluidRecipe {
         return consume;
     }
 
-    public IIngredient getInputs() {
+    public IIngredient[] getInputs() {
         return inputs;
-    }
-
-    public int getInputAmount() {
-        return inputAmount;
     }
 }

--- a/src/main/java/xt9/inworldcrafting/common/recipe/FluidToItemRecipe.java
+++ b/src/main/java/xt9/inworldcrafting/common/recipe/FluidToItemRecipe.java
@@ -2,7 +2,6 @@ package xt9.inworldcrafting.common.recipe;
 
 import crafttweaker.api.item.IIngredient;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.NonNullList;
 
 import java.util.ArrayList;
 
@@ -14,20 +13,18 @@ public class FluidToItemRecipe {
 
     private ItemStack outputStack;
     private String inputFluid;
-    private IIngredient inputs;
-    private int inputAmount;
+    private IIngredient[] inputs;
     private boolean consume;
 
-    private FluidToItemRecipe(ItemStack outputStack, String inputFluid, IIngredient inputs, int inputAmount, boolean consume) {
+    private FluidToItemRecipe(ItemStack outputStack, String inputFluid, IIngredient[] inputs, boolean consume) {
         this.outputStack = outputStack;
         this.inputFluid = inputFluid;
         this.inputs = inputs;
         this.consume = consume;
-        this.inputAmount = inputAmount;
     }
 
-    public static void addRecipe(ItemStack outputItem, String inputFluid, IIngredient inputs, int inputAmount, boolean consume) {
-        recipes.add(new FluidToItemRecipe(outputItem, inputFluid, inputs, inputAmount, consume));
+    public static void addRecipe(ItemStack outputItem, String inputFluid, IIngredient[] inputs, boolean consume) {
+        recipes.add(new FluidToItemRecipe(outputItem, inputFluid, inputs, consume));
     }
 
     public ItemStack getOutputStack() {
@@ -42,11 +39,7 @@ public class FluidToItemRecipe {
         return consume;
     }
 
-    public int getInputAmount() {
-        return inputAmount;
-    }
-
-    public IIngredient getInputs() {
+    public IIngredient[] getInputs() {
         return inputs;
     }
 }

--- a/src/main/java/xt9/inworldcrafting/common/util/WorldHelper.java
+++ b/src/main/java/xt9/inworldcrafting/common/util/WorldHelper.java
@@ -1,0 +1,40 @@
+package xt9.inworldcrafting.common.util;
+
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author ExpensiveKoala on 2/13/2019
+ */
+public class WorldHelper {
+    public static List<EntityItem> getAllItemEntitiesAtPosition(World world, BlockPos pos) {
+        return getAllItemEntitiesAtPosition(world, pos, 1);
+    }
+
+    public static List<EntityItem> getAllItemEntitiesAtPosition(World world, BlockPos pos, int radius) {
+        return world.getEntitiesWithinAABB(EntityItem.class, new AxisAlignedBB(pos.getX() - radius, pos.getY() - radius, pos.getZ() - radius, pos.getX() + radius, pos.getY() + radius, pos.getZ() + radius));
+    }
+
+    public static List<ItemStack> getAllItemStacksAtPosition(World world, BlockPos pos){
+        return getAllItemStacksAtPosition(world, pos, 1);
+    }
+
+    public static List<ItemStack> getAllItemStacksAtPosition(World world, BlockPos pos, int radius){
+        return getAllItemEntitiesAtPosition(world, pos, radius).stream().map(EntityItem::getItem).collect(Collectors.toList());
+    }
+
+    public static List<Item> getAllItemsAtPosition(World world, BlockPos pos) {
+        return getAllItemsAtPosition(world, pos, 1);
+    }
+
+    public static List<Item> getAllItemsAtPosition(World world, BlockPos pos, int radius) {
+        return getAllItemStacksAtPosition(world, pos, radius).stream().map(ItemStack::getItem).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/xt9/inworldcrafting/integrations/jei/FluidToFluidRecipeWrapper.java
+++ b/src/main/java/xt9/inworldcrafting/integrations/jei/FluidToFluidRecipeWrapper.java
@@ -22,7 +22,7 @@ public class FluidToFluidRecipeWrapper implements IRecipeWrapper {
 
     @Override
     public void getIngredients(IIngredients ingredients) {
-        ingredients.setInput(ItemStack.class, IngredientHelper.getStacksFromIngredient(recipe.getInputs()));
+        ingredients.setInput(ItemStack.class, IngredientHelper.getStacksFromIngredient(recipe.getInputs()[0]));
         ingredients.setInput(FluidStack.class, new FluidStack(FluidRegistry.getFluid(recipe.getInputFluid()), 1000));
         ingredients.setOutput(FluidStack.class, new FluidStack(FluidRegistry.getFluid(recipe.getOutputFluid()), 1000));
     }

--- a/src/main/java/xt9/inworldcrafting/integrations/jei/FluidToItemRecipeWrapper.java
+++ b/src/main/java/xt9/inworldcrafting/integrations/jei/FluidToItemRecipeWrapper.java
@@ -22,7 +22,7 @@ public class FluidToItemRecipeWrapper implements IRecipeWrapper {
 
     @Override
     public void getIngredients(IIngredients ingredients) {
-        ingredients.setInput(ItemStack.class, IngredientHelper.getStacksFromIngredient(recipe.getInputs()));
+        ingredients.setInput(ItemStack.class, IngredientHelper.getStacksFromIngredient(recipe.getInputs()[0]));
         ingredients.setInput(FluidStack.class, new FluidStack(FluidRegistry.getFluid(recipe.getInputFluid()), 1000));
         ingredients.setOutput(ItemStack.class, recipe.getOutputStack());
     }


### PR DESCRIPTION
Adds support for inputstack arrays from #4 to FluidToFluid and FluidToItem transformations.

Also, as a result it allows for defining an input stack larger than max stack size. Although, to achieve this it is now tracking all item entities that are of an item that is used in a recipe. 
_(Before it was only tracking an item entity if it had equal or more count to the recipe. For example: 1 diamond wouldn't get tracked, but 3 would if the input stack was <minecraft:diamond>*3)_
If this behavior is not something you want, then removing the `.amount(1)` from https://github.com/ExpensiveKoala/InWorldCrafting/blob/master/src/main/java/xt9/inworldcrafting/common/event/EntityMatcher.java#L37, https://github.com/ExpensiveKoala/InWorldCrafting/blob/master/src/main/java/xt9/inworldcrafting/common/event/EntityMatcher.java#L63, and https://github.com/ExpensiveKoala/InWorldCrafting/blob/master/src/main/java/xt9/inworldcrafting/common/event/EntityMatcher.java#L75 should remove that behavior.

If removed, then it would only allow for inputstacks up to max stack size. I believe doing 

`mods.inworldcrafting.FluidToItem.transform(<minecraft:iron_ore>, <liquid:water>, [<minecraft:planks:2>*64, <minecraft:planks:2>*64 ]);` 

instead of

 `mods.inworldcrafting.FluidToItem.transform(<minecraft:iron_ore>, <liquid:water>, <minecraft:planks:2>*128);` 

should still work.

[Here](https://i.imgur.com/kW1bJeO.gif) is a gif showing the recipes:
* `mods.inworldcrafting.FluidToItem.transform(<minecraft:iron_ore>, <liquid:water>, <minecraft:planks:2>*128);`
* `mods.inworldcrafting.FluidToItem.transform(<minecraft:diamond_ore>, <liquid:water>, [<minecraft:planks>, <minecraft:coal>]);`
* `mods.inworldcrafting.FluidToFluid.transform(<liquid:lava>, <liquid:water>, [<minecraft:stick>, <minecraft:diamond>*3]);`

One thing that this PR doesn't fix, is the JEI integration. I'm not a good artist, nor am I good at designing GUIs. I'm not sure how is the best way to display the added functionality on the JEI recipe, so to avoid crashing, it is simply showing the first item in the input list.